### PR TITLE
Add 9m2ibr_aprs_lora_tracker

### DIFF
--- a/build_list.yaml
+++ b/build_list.yaml
@@ -1,6 +1,13 @@
 build_variants:
   # ESP32 devices
   - device_type: esp32
+    device_name: 9m2ibr_aprs_lora_tracker
+    pio_target: 9m2ibr_aprs_lora_tracker
+    build_options:
+      - daily_build: false
+      - release_build: true
+
+  - device_type: esp32
     device_name: heltec-v2_0
     pio_target: heltec-v2_0
     build_options:


### PR DESCRIPTION
Board was added to upstream in PR meshtastic/firmware#7828, commit 484ec87, tag/release v2.7.9.70724be.