### PR TITLE
Add repo with T-Deck russian keyboard firmware

### DIFF
--- a/build_list_svk.yaml
+++ b/build_list_svk.yaml
@@ -1,0 +1,11 @@
+github_source: skrashevich/meshtastic-firmware
+
+build_variants:
+  - device_name: T-Deck (RU screen+physical keyboards)
+    pio_target: t-deck-tft
+    build_name: t-deck-tft-ru
+    device_type: esp32
+    build_options:
+      - daily_build: true
+      - release_build: true
+    build_flags: -D OLED_RU


### PR DESCRIPTION
This pull request adds a new build configuration for the T-Deck device with Russian screen and physical keyboard support. The configuration specifies the source repository, build variant details, and relevant build flags.

Build configuration additions:

* Added a new build variant for the T-Deck device with Russian screen and physical keyboards, including the `pio_target`, `build_name`, `device_type`, and build flags for Russian OLED support in `build_list_svk.yaml`.
* Set both `daily_build` and `release_build` options to true for this new variant.
* Specified the source repository as `skrashevich/meshtastic-firmware`.