### PR TITLE
add NRF52 Pro-micro DIY (OLED 1.3", RU, P-channel GPS transistor) target

### DIFF
--- a/build_list.yaml
+++ b/build_list.yaml
@@ -640,6 +640,15 @@ build_variants:
     build_flags: -D OLED_RU -D GPS_EN_ACTIVE=0
 
   - device_type: nrf52
+    device_name: NRF52 Pro-micro DIY (OLED 1.3", RU, P-channel GPS transistor)
+    build_name: nrf52_promicro_diy_tcxo_gps_act_0_ru_oled_1.3
+    pio_target: nrf52_promicro_diy_tcxo
+    build_options:
+      - daily_build: false
+      - release_build: true
+    build_flags: -D OLED_RU -D USE_SH1106 -D GPS_EN_ACTIVE=0
+
+  - device_type: nrf52
     device_name: E73 (slim)
     pio_target: e73_slim
     build_options:


### PR DESCRIPTION
Добавил поддержку 1.3" экранов на плате с P-канальным транзистором на GPS